### PR TITLE
Add docker configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+# Update and save as .env if using docker
+OPENAI_API_KEY=Your-API-Key
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@
 ## Run with # docker exec -it autocoder python start.py
 ##
 #
-##Settings commented for the following:
+## Settings commented for the following:
 #
-#Expose ports for your autocoder
-#Map it's workdir to a local system dir to more easily interact with it's files
-#Adjust the current hardcap of 90% CPU usage and 7GB ram usage
+# Expose ports for your autocoder
+# You may wish to map it's project_data dir to a different or unique dir
+# Adjust the current hardcap of 90% CPU usage and 7GB ram usage
 #
 version: '3'
 services:
@@ -19,8 +19,8 @@ services:
 ## Update ports if you need them exposed
 #    ports:
 #      - "7860:7860"
-#    volumes:
-#      - /your/local/folder:/app
+    volumes:
+      - ./project_data:/app/project_data
     env_file:
       - .env
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+### Autocoder docker-compose
+#
+## Build with # docker-compose up -d --build
+## Run with # docker exec -it autocoder python start.py
+##
+#
+##Settings commented for the following:
+#
+#Expose ports for your autocoder
+#Map it's workdir to a local system dir to more easily interact with it's files
+#Adjust the current hardcap of 90% CPU usage and 7GB ram usage
+#
+version: '3'
+services:
+  autocoder:
+    container_name: autocoder
+    build: 
+      context: .
+## Update ports if you need them exposed
+#    ports:
+#      - "7860:7860"
+#    volumes:
+#      - /your/local/folder:/app
+    env_file:
+      - .env
+    deploy:
+      resources:
+        limits:
+## Adjust limits of CPU % and max ram usage
+          cpus: '0.9'
+          memory: 7G

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,23 @@
+# Use an official Python runtime as a parent image
+FROM python:slim-buster
+
+# Set the working directory in the container to /app
+WORKDIR /app
+
+# Add the parent directory contents into the container at /app
+ADD . /app
+
+# Create .preferences file as blank json
+RUN echo "{}" > .preferences
+
+# Install build essentials for gcc, required for buidling some of the following python requirements
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential
+
+# Install any needed packages specified in requirements.txt
+RUN pip install .
+
+
+# Run a shell upon starting up and keep it running
+CMD tail -f /dev/null
+


### PR DESCRIPTION
Thought it might be worth sandboxing the instance, at least I am for my own sanity.

This pull request lets users configure a basic python docker image build, and has a few suggestions for things to change in the docker-compose.yml as per each user's own needs.

Default capped max CPU usage at 90% and max ram at 7GB to avoid things getting unintentionally too out of control.

.env already in .gitignore so no need to make changes there

Build with # docker-compose up -d --build
Run with # docker exec -it autocoder python start.py
